### PR TITLE
[Feature] 거래글 이미지 업로드 구현   [Fix] 레시피 리뷰 구조 변경

### DIFF
--- a/src/main/java/com/example/springjwt/market/TradePost.java
+++ b/src/main/java/com/example/springjwt/market/TradePost.java
@@ -36,5 +36,10 @@ public class TradePost {
     @Column(length = 1000)
     private String description;
 
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String imageUrls; // JSON 형식의 이미지 URL 리스트
+
     private String location; // 거래 희망 장소 (추후 지도 기능 연동)
+
 }

--- a/src/main/java/com/example/springjwt/market/TradePostDTO.java
+++ b/src/main/java/com/example/springjwt/market/TradePostDTO.java
@@ -20,6 +20,7 @@ public class TradePostDTO {
     private LocalDate purchaseDate; // 구매 날짜
     private String description;     // 설명
     private String location;        // 거래 희망 장소 (추후 사용)
+    private String imageUrls;       // 이미지 URL 목록 (JSON 문자열)
 
     // DTO → Entity (User는 외부에서 주입)
     public TradePost toEntity() {
@@ -31,6 +32,7 @@ public class TradePostDTO {
                 .purchaseDate(purchaseDate)
                 .description(description)
                 .location(location)
+                .imageUrls(imageUrls)
                 .build();
     }
 
@@ -46,6 +48,7 @@ public class TradePostDTO {
                 .purchaseDate(tradePost.getPurchaseDate())
                 .description(tradePost.getDescription())
                 .location(tradePost.getLocation())
+                .imageUrls(tradePost.getImageUrls())
                 .build();
     }
 }

--- a/src/main/java/com/example/springjwt/review/Review.java
+++ b/src/main/java/com/example/springjwt/review/Review.java
@@ -34,7 +34,9 @@ public class Review {
     @Column(nullable = false)
     private int rating; // 별점 (1~5)
 
-    private String mediaUrl; // 이미지 URL (선택사항)
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String mediaUrls; // 이미지 URL 리스트 (JSON 형식 문자열)
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt; // 작성일시

--- a/src/main/java/com/example/springjwt/review/ReviewRequestDTO.java
+++ b/src/main/java/com/example/springjwt/review/ReviewRequestDTO.java
@@ -1,4 +1,6 @@
 package com.example.springjwt.review;
+import com.example.springjwt.User.UserEntity;
+import com.example.springjwt.recipe.Recipe;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,5 +10,14 @@ public class ReviewRequestDTO {
     private Long recipeId;
     private String content;
     private int rating;
-    private String mediaUrl;
+    private String mediaUrls;
+    public Review toEntity(UserEntity user, Recipe recipe) {
+        return Review.builder()
+                .user(user)
+                .recipe(recipe)
+                .content(content)
+                .rating(rating)
+                .mediaUrls(mediaUrls)
+                .build();
+    }
 }

--- a/src/main/java/com/example/springjwt/review/ReviewResponseDTO.java
+++ b/src/main/java/com/example/springjwt/review/ReviewResponseDTO.java
@@ -1,24 +1,28 @@
 package com.example.springjwt.review;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-
+@Builder
 @Getter
 public class ReviewResponseDTO {
     private Long reviewId;
     private String content;
     private int rating;
-    private String mediaUrl;
+    private String mediaUrls;
     private LocalDateTime createdAt;
     private String username; // 리뷰 작성자
 
-    public ReviewResponseDTO(Review review) {
-        this.reviewId = review.getReviewId();
-        this.content = review.getContent();
-        this.rating = review.getRating();
-        this.mediaUrl = review.getMediaUrl();
-        this.createdAt = review.getCreatedAt();
-        this.username = review.getUser().getUsername(); // 사용자 이름 반환
+    public static ReviewResponseDTO fromEntity(Review review) {
+        return ReviewResponseDTO.builder()
+                .reviewId(review.getReviewId())
+                .content(review.getContent())
+                .rating(review.getRating())
+                .mediaUrls(review.getMediaUrls())
+                .createdAt(review.getCreatedAt())
+                .username(review.getUser().getUsername())
+                .build();
     }
+
 }

--- a/src/main/java/com/example/springjwt/review/ReviewService.java
+++ b/src/main/java/com/example/springjwt/review/ReviewService.java
@@ -38,23 +38,18 @@ public class ReviewService {
         Recipe recipe = recipeRepository.findById(dto.getRecipeId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 레시피가 없습니다."));
 
-        // 리뷰 저장
-        Review review = Review.builder()
-                .recipe(recipe)
-                .user(user)
-                .content(dto.getContent())
-                .rating(dto.getRating())
-                .mediaUrl(dto.getMediaUrl())
-                .build();
+        Review review = dto.toEntity(user, recipe);
 
         reviewRepository.save(review);
-        return new ReviewResponseDTO(review);
+        return ReviewResponseDTO.fromEntity(review);
     }
 
     // 특정 레시피의 리뷰 조회
     @Transactional(readOnly = true)
     public List<ReviewResponseDTO> getReviewsByRecipe(Long recipeId) {
         List<Review> reviews = reviewRepository.findByRecipe_RecipeId(recipeId);
-        return reviews.stream().map(ReviewResponseDTO::new).collect(Collectors.toList());
+        return reviews.stream()
+                .map(ReviewResponseDTO::fromEntity)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
### 📌 변경 사항

#### 1. 거래글 이미지 업로드 기능 구현
- 거래글 작성 시 이미지 여러 개 업로드 가능
- 이미지 URI 리스트를 JSON 문자열로 변환하여 서버 전송
- `TradePostDTO`, `TradePost` 엔티티에 `imageUrls: String` 필드 추가
- 서버에서 `@Lob`, `@Column(columnDefinition = "TEXT")`로 저장 처리

#### 2. 레시피 리뷰 구조 변경
- `Review` 엔티티 구조 리팩토링
  - 기존 리뷰 필드(content, rating, createdAt 등) 유지
  - 이미지가 있을 경우 `mediaUrl`로 저장
- DTO, 서비스, 컨트롤러 레이어 일관성 있게 수정

---

### ✅ 테스트
- 거래글 작성 시 이미지 정상 업로드 및 저장 확인
- 레시피 리뷰 작성/조회 시 새로운 구조로 문제 없이 동작

---

### 📎 관련 이슈
- #거래글 이미지 업로드
- #레시피 리뷰 구조 리팩토링
